### PR TITLE
Fix EZP-23911: ezwordtoimageoperator with $size[0]

### DIFF
--- a/kernel/common/ezwordtoimageoperator.php
+++ b/kernel/common/ezwordtoimageoperator.php
@@ -268,7 +268,7 @@ class eZWordToImageOperator
                 }
                 else
                 {
-                    $size = $sizes[0];
+                    $size = reset( $sizes );
                 }
 
                 $pathDivider = strpos( $size, ';' );


### PR DESCRIPTION
when $size is an associative array, $size[0] does not exists.
Using reset will return the first item.

ex. in ezpublish_legacy/share/icons/crystal-admin/icon.ini

```
[IconSettings]
# Defined sizes, each size refers to the name of the subdirectory
# of the icon theme. If the name contains two numbers with an
# x in between it will be considered to be the width and height
# of the icon, if not no size is will be given
Sizes[]
Sizes[normal]=32x32
Sizes[small]=16x16_indexed
Sizes[ghost]=16x16_ghost
Sizes[original]=16x16_original
```

see. Jira EZP-23911 https://jira.ez.no/browse/EZP-23911
